### PR TITLE
Read epic items with utf8 encoding and better usability

### DIFF
--- a/src/lib/egs/egs.py
+++ b/src/lib/egs/egs.py
@@ -68,7 +68,7 @@ class EGS:
 
         for manifest_name in filter(is_manifest, os.listdir(manifest_path)):
             try:
-                with open(os.path.join(manifest_path, manifest_name)) as fd:
+                with open(os.path.join(manifest_path, manifest_name), encoding="utf8") as fd:
                     manifest = json.load(fd)
                     if os.path.exists(manifest["InstallLocation"]):
                         games.append({

--- a/src/lib/egs/egs.py
+++ b/src/lib/egs/egs.py
@@ -14,7 +14,7 @@ class EGS:
         self.__context = context
         self.__valid = False
         install_path = self.__find_store()
-        context.info("install path", install_path)
+        context.dbg("install path", install_path)
 
         self.__exe_path = self.__get_exe_path()
 
@@ -46,18 +46,18 @@ class EGS:
             self.__valid = True
             return data_path[0]
         except Exception as e:
-            self.__context.info("Failed to find path, maybe it isn't installed", e)
+            self.__context.warn("Failed to find path, maybe it isn't installed", e)
 
     def __get_exe_path(self):
         try:
             root = ConnectRegistry(None, HKEY_LOCAL_MACHINE)
             base_key = OpenKeyEx(root, EGS.ICON_PATH)
             data_path = QueryValueEx(base_key, "")
-            self.__context.info("data path", data_path)
+            self.__context.dbg("data path", data_path)
             self.__valid = True
             return data_path[0].split(",")[0]
         except Exception as e:
-            self.__context.info("Failed to find executable, maybe it isn't installed", e)
+            self.__context.warn("Failed to find executable, maybe it isn't installed", e)
 
     def __read_manifest(self, install_path):
         manifest_path = os.path.join(install_path, "Manifests")

--- a/src/lib/origin/origin.py
+++ b/src/lib/origin/origin.py
@@ -13,7 +13,7 @@ class Origin:
         self.__context = context
         self.__valid = False
         self.__exe_path = self.__find_store()
-        context.info("install path", os.path.dirname(self.__exe_path))
+        context.dbg("install path", os.path.dirname(self.__exe_path))
 
         self.__games = self.__read_manifest(self.__exe_path)
 
@@ -44,7 +44,7 @@ class Origin:
             self.__valid = True
             return data_path[0]
         except Exception as e:
-            self.__context.info("Failed to find store path, maybe it isn't installed", e)
+            self.__context.warn("Failed to find store path, maybe it isn't installed", e)
 
     def __read_manifest(self, install_path):
         manifests_path = os.path.join(os.environ["ProgramData"], "Origin", "LocalContent")

--- a/src/lib/steam/steam.py
+++ b/src/lib/steam/steam.py
@@ -93,11 +93,11 @@ class Steam:
         self.__context = context
         self.__valid = False
         self.__exe_path, self.__install_path = self.__get_install_path()
-        context.info("install path", self.__install_path)
+        context.dbg("install path", self.__install_path)
         self.__appinfo = self.__get_appinfo(self.__install_path)
         library_paths = self.__get_library_paths(self.__install_path)
         library_paths.insert(0, self.__install_path)
-        context.info("libraries", library_paths)
+        context.dbg("libraries", library_paths)
 
         games = []
         for library in library_paths:
@@ -111,7 +111,7 @@ class Steam:
             game = next(game for game in self.__games if game["appid"] == appid)
             launcher: dict = game["launchers"][launcher_id]
             if "executable" in launcher:
-                self.__context.info("starting steam game with launcher", launcher)
+                self.__context.dbg("starting steam game with launcher", launcher)
                 return self.run_directly(kpu, game, launcher, appid, call_args)
 
         return self.run_through_steam(kpu, appid, call_args)
@@ -125,7 +125,7 @@ class Steam:
             # since we're not running with steam -applaunch, steam will not be started
             # automatically but some games won't run correctly
             if not is_steam_running():
-                self.__context.info("steam not running, starting it now")
+                self.__context.dbg("steam not running, starting it now")
                 kpu.shell_execute(self.__exe_path)
                 # arbitrary, is 5 seconds enough? I think as long as steam is starting up
                 # the game will wait if necessary for it to complete initializing
@@ -137,7 +137,7 @@ class Steam:
 
     def run_through_steam(self, kpu, appid: str, call_args: str):
         target = "-applaunch {} {}".format(appid, call_args)
-        self.__context.info(
+        self.__context.dbg(
             "starting steam game through applaunch link", target)
         kpu.shell_execute(self.__exe_path, args=target)
 
@@ -186,7 +186,7 @@ class Steam:
             self.__valid = True
             return res_exe[0], os.path.normpath(res_path[0])
         except Exception as e:
-            self.__context.info("Failed to find path, maybe isn't installed", e)
+            self.__context.warn("Failed to find path, maybe isn't installed", e)
 
     def __get_appinfo(self, install_path: str):
         with open(os.path.join(install_path, 'appcache', 'appinfo.vdf'), "rb") as fd:

--- a/src/lib/windowsstore/windowsstore.py
+++ b/src/lib/windowsstore/windowsstore.py
@@ -96,7 +96,7 @@ class WindowsStore:
                     visuals = app.getElementsByTagName("uap:VisualElements")[0]
                     logo_path = visuals.getAttribute("Square150x150Logo")
                 except Exception as e:
-                    self.__context.info("failed to get logo", exeid, e)
+                    self.__context.warn("failed to get logo", exeid, e)
 
                 id_parts = sub_key_name.split("_")
                 games.append({


### PR DESCRIPTION
Main thing first:
Read the `*.item` json files for the epic launcher with utf8 encoding (the trademark signs were not correctly shown for "Tony Hawk's™ Pro Skater™ 1 + 2")

Some more usability stuff:
* don't log unnecessary with `info()` which is supposed to be `dbg()`
* also log with `warn()` instead of `info()` when exceptions occur
* load settings `on_start` and if they change (via `on_event`)
* search for games and catalog them in `on_catalog` instead of doing the searching only `on_start` (that way "Keypirinha: Refresh Catalog: allmygames" actually searches again for games without a restart of KP)
* only search for a launcher and its games if the launcher is actually enabled
* list and dict comprehension is awesome :)